### PR TITLE
CH7569: Add resolution date to kayako import

### DIFF
--- a/importers/kayako/src/Kayako/KayakoImporter.php
+++ b/importers/kayako/src/Kayako/KayakoImporter.php
@@ -322,6 +322,7 @@ class KayakoImporter extends AbstractImporter
                 'person'        => $person,
                 'agent'         => $this->writer()->agentOid($n['staffid']),
                 'date_created'  => date('c', $n['dateline']),
+                'date_resolved' => date('c', $n['resolutiondateline']),
                 'custom_fields' => [
                     [
                         'name'  => 'Original ID',


### PR DESCRIPTION
Previously, the "date_resolved" was incorrectly populated with the datetime the import ran. There is a row in swtickets schema for `resolutiondateline`, which we can pull over.